### PR TITLE
Fix build for supported .NET examples

### DIFF
--- a/Tableau-Supported/DotNet/Example.csproj
+++ b/Tableau-Supported/DotNet/Example.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <PackageReference Include="Tableau.HyperAPI.NET" Version="0.0.11355" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tableau-Supported/DotNet/build.bat
+++ b/Tableau-Supported/DotNet/build.bat
@@ -1,4 +1,2 @@
 SETLOCAL EnableDelayedExpansion
 dotnet build Example.csproj || exit /b !ERRORLEVEL!
-xcopy /Y ..\lib\tableauhyperapi.dll bin\Debug\netcoreapp3.1\ || exit /b !ERRORLEVEL!
-xcopy /E /Y ..\lib\hyper bin\Debug\netcoreapp3.1\hyper\ || exit /b !ERRORLEVEL!

--- a/Tableau-Supported/DotNet/build.sh
+++ b/Tableau-Supported/DotNet/build.sh
@@ -1,4 +1,2 @@
 set -e
 dotnet build Example.csproj
-cp -R ../lib/hyper bin/Debug/netcoreapp3.1
-cp -R ../lib/libtableauhyperapi.* bin/Debug/netcoreapp3.1/


### PR DESCRIPTION
There were three issues:

* The `Example.csproj` was missing a package reference to the .NET
  Tableau Hyper API
* `build.sh` and `build.bat` tried to copy non-existing files
* `build.sh` was not marked as executable

This commit fixes all three issues and should ensure that enlisting
the .NET examples and running the build file will successfully build
the examples.