### PR TITLE
Add Hyper file format example

### DIFF
--- a/Community-Supported/README.md
+++ b/Community-Supported/README.md
@@ -8,6 +8,8 @@ The community samples focus on individual use cases and are Python-only. They ha
 ## What samples are available?
 - [__adjust-vertex-order__](https://github.com/tableau/hyper-api-samples/tree/main/Community-Supported/adjust-vertex-order)
   - Demonstrates how to adjust the vertex order of all polygons in a `.hyper` file by copying all of the tables and data and calling transformative SQL function on all columns of type `GEOGRAPHY`.
+- [__convert_hyper_file__](https://github.com/tableau/hyper-api-samples/tree/main/Community-Supported/convert-hyper-file)
+  - Demonstrates how to convert an existing `.hyper` file to a newer or older Hyper file format by copying all of the tables and data into a new file.
 - [__defragment_data_of_existing_hyper_file__](https://github.com/tableau/hyper-api-samples/tree/main/Community-Supported/defragment-hyper-file)
   - Demonstrates how to optimize the file storage of an existing `.hyper` file by copying all of the tables and data into a new file to reduce file fragmentation.
 - [__hyper-jupyter-kernel__](https://github.com/tableau/hyper-api-samples/tree/main/Community-Supported/hyper-jupyter-kernel)

--- a/Community-Supported/convert-hyper-file/README.md
+++ b/Community-Supported/convert-hyper-file/README.md
@@ -1,0 +1,56 @@
+# convert-hyper-file
+## __convert_hyper_file__
+
+
+
+![Community Supported](https://img.shields.io/badge/Support%20Level-Community%20Supported-53bd92.svg)
+
+__Current Version__: 1.0
+
+This sample demonstrates how you can upgrade or downgrade an existing `.hyper` file to a newer or older Hyper file format by copying all of the tables and data into a new file.
+
+Fore more information on the Hyper file formats, see [Hyper Process Settings](https://help.tableau.com/current/api/hyper_api/en-us/reference/sql/databasesettings.html#DEFAULT_DATABASE_VERSION).
+
+# Get started
+
+## __Prerequisites__
+
+To run the script, you will need:
+
+- a computer running Windows, macOS, or Linux
+
+- Python 3.6 or 3.7
+
+## Run the sample
+
+As a quick test of how the sample works, you don't need to make any changes to the `convert_hyper_file.py` file. You can simply run the sample on a `.hyper` file to see how it downgrades a Hyper file to the initial file format version 0. The Python sample reads an existing `.hyper` file and copies all the tables and data into a new file.
+
+Ensure that you have installed the requirements and then just run the sample Python file.
+The following instructions assume that you have set up a virtual environment for Python. For more information on creating virtual environments, see [venv - Creation of virtual environments](https://docs.python.org/3/library/venv.html) in the Python Standard Library.
+
+1. Open a terminal and activate the Python virtual environment (`venv`).
+
+1. Navigate to the folder where you installed the sample.
+
+1. Run the Python script against an existing `.hyper` file. The syntax for running the script is:
+   
+   **python convert_hyper_file.py [-h] [--output-hyper-file-path OUTPUT_HYPER_FILE_PATH] [--output-hyper-file-version OUTPUT_HYPER_FILE_VERSION] input_hyper_file_path**
+
+   If you do not specify an output file, a new file is created with the same name and with `.[new version].hyper` as the file name extension. The new version of the file contains all the data of the existing file with the specified version.
+
+   Example:
+    
+    ```cli
+    (venv)c:\mydir> python convert_hyper_file.py -o NewVersionFile.hyper -v 1 OldVersionFile.hyper
+    Successfully converted table "input_database"."Extract"."Extract"
+    Successfully converted OldVersionFile.hyper into NewVersionFile.hyper
+   ```
+
+## __Resources__
+Check out these resources to learn more:
+
+- [Hyper API docs](https://help.tableau.com/current/api/hyper_api/en-us/index.html)
+
+- [Tableau Hyper API Reference (Python)](https://help.tableau.com/current/api/hyper_api/en-us/reference/py/index.html)
+
+- [Hyper API SQL Reference](https://help.tableau.com/current/api/hyper_api/en-us/reference/sql/index.html)

--- a/Community-Supported/convert-hyper-file/convert_hyper_file.py
+++ b/Community-Supported/convert-hyper-file/convert_hyper_file.py
@@ -1,0 +1,32 @@
+import argparse
+from pathlib import PurePath
+from tableauhyperapi import HyperProcess, Telemetry, Connection, TableDefinition, TableName
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(description="This tool converts the given Hyper file to the selected file format version. Per default, it will downgrade to the initial file format (version 0).")
+    argparser.add_argument("input_hyper_file_path", type=PurePath, help="The input Hyper file path that will be converted to selected file format version")
+    argparser.add_argument("--output-hyper-file-path", "-o", type=PurePath, help="The output Hyper file path for the converted output Hyper file")
+    argparser.add_argument("--output-hyper-file-version", "-v", type=int, help="The output Hyper file version for the converted output Hyper file. Defaults to the initial file format (version 0)", default=0)
+    args = argparser.parse_args()
+    if not args.output_hyper_file_path:
+        args.output_hyper_file_path = args.input_hyper_file_path.parent / (args.input_hyper_file_path.stem + f".version{args.output_hyper_file_version}.hyper")
+
+    with HyperProcess(telemetry=Telemetry.SEND_USAGE_DATA_TO_TABLEAU, parameters={"default_database_version": f"{args.output_hyper_file_version}"}) as hyper:
+        with Connection(endpoint=hyper.endpoint) as connection:
+            # Create the output Hyper file or overwrite it
+            catalog = connection.catalog
+            catalog.drop_database_if_exists(args.output_hyper_file_path)
+            catalog.create_database(args.output_hyper_file_path)
+            catalog.attach_database(args.output_hyper_file_path, alias="output_database")
+            catalog.attach_database(args.input_hyper_file_path, alias="input_database")
+
+            # Process all tables of all schemas of the input Hyper file and copy them into the output Hyper file
+            for input_schema_name in catalog.get_schema_names("input_database"):
+                for input_table_name in catalog.get_table_names(input_schema_name):
+                    output_table_name = TableName("output_database", input_schema_name.name, input_table_name.name)
+                    output_table_definition = TableDefinition(output_table_name, catalog.get_table_definition(input_table_name).columns)
+                    catalog.create_schema_if_not_exists(output_table_name.schema_name)
+                    catalog.create_table(output_table_definition)
+                    connection.execute_command(f"INSERT BULK INTO {output_table_name} (SELECT * FROM {input_table_name})")
+                    print(f"Successfully converted table {input_table_name}")
+            print(f"Successfully converted {args.input_hyper_file_path} into {args.output_hyper_file_path}")


### PR DESCRIPTION
This example demonstrates how you can upgrade or downgrade an existing `.hyper` file to a newer or older Hyper file format by copying all of the tables and data into a new file.