### PR TITLE
Update config in extractor_cli.py

### DIFF
--- a/Community-Supported/clouddb-extractor/extractor_cli.py
+++ b/Community-Supported/clouddb-extractor/extractor_cli.py
@@ -122,7 +122,7 @@ def get_int_from_arg(this_str, arg_name, is_required=False):
 
 def main():
     # Load defaults
-    config = yaml.safe_load(open("config.yml"))
+    config = yaml.safe_load(open(CONFIGURATION_FILE))
 
     # Define Command Line Args
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
The proposed change uses the CONFIGURATION_FILE global as the target for yaml.safe_load(), rather than always loading "config.yaml". 

I believe this was the intended use of the CONFIGURATION_FILE variable, however it currently is not used anywhere in the script.