### PR TITLE
Remove Tableau copyright headers

### DIFF
--- a/Tableau-Supported/CPP/CMakeLists.txt
+++ b/Tableau-Supported/CPP/CMakeLists.txt
@@ -1,14 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# Unlicensed use of the contents of this file is prohibited. Please refer to
-# the NOTICES.txt file for further details.
-#
-# -----------------------------------------------------------------------------
-
 # This is an example CMake project that builds and tests the included C++ example code.
 #
 # To configure this project, run

--- a/Tableau-Supported/CPP/create_hyper_file_from_csv.cpp
+++ b/Tableau-Supported/CPP/create_hyper_file_from_csv.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example create_hyper_file_from_csv.cpp
  *

--- a/Tableau-Supported/CPP/delete_data_in_existing_hyper_file.cpp
+++ b/Tableau-Supported/CPP/delete_data_in_existing_hyper_file.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example delete_data_in_existing_hyper_file.cpp
  *

--- a/Tableau-Supported/CPP/insert_data_into_multiple_tables.cpp
+++ b/Tableau-Supported/CPP/insert_data_into_multiple_tables.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example insert_data_into_multiple_tables.cpp
  *

--- a/Tableau-Supported/CPP/insert_data_into_single_table.cpp
+++ b/Tableau-Supported/CPP/insert_data_into_single_table.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example insert_data_into_single_table.cpp
  *

--- a/Tableau-Supported/CPP/insert_data_with_expressions.cpp
+++ b/Tableau-Supported/CPP/insert_data_with_expressions.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example insert_data_with_expressions.cpp
  *

--- a/Tableau-Supported/CPP/insert_spatial_data_to_a_hyper_file.cpp
+++ b/Tableau-Supported/CPP/insert_spatial_data_to_a_hyper_file.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example insert_spatial_data_to_a_hyper_file.cpp
  *

--- a/Tableau-Supported/CPP/read_and_print_data_from_existing_hyper_file.cpp
+++ b/Tableau-Supported/CPP/read_and_print_data_from_existing_hyper_file.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 /**
  * \example read_and_print_data_from_existing_hyper_file.cpp
  *

--- a/Tableau-Supported/CPP/update_data_in_existing_hyper_file.cpp
+++ b/Tableau-Supported/CPP/update_data_in_existing_hyper_file.cpp
@@ -1,14 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-
 #include <fstream>
 #include <hyperapi/hyperapi.hpp>
 #include <iostream>

--- a/Tableau-Supported/DotNet/CreateHyperFileFromCsv.cs
+++ b/Tableau-Supported/DotNet/CreateHyperFileFromCsv.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 using System.IO;
 using System.Collections.Generic;

--- a/Tableau-Supported/DotNet/DeleteDataInExistingHyperFile.cs
+++ b/Tableau-Supported/DotNet/DeleteDataInExistingHyperFile.cs
@@ -1,14 +1,4 @@
-﻿// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;

--- a/Tableau-Supported/DotNet/InsertDataIntoMultipleTables.cs
+++ b/Tableau-Supported/DotNet/InsertDataIntoMultipleTables.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 
 using Tableau.HyperAPI;

--- a/Tableau-Supported/DotNet/InsertDataIntoSingleTable.cs
+++ b/Tableau-Supported/DotNet/InsertDataIntoSingleTable.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 
 using Tableau.HyperAPI;

--- a/Tableau-Supported/DotNet/InsertDataWithExpressions.cs
+++ b/Tableau-Supported/DotNet/InsertDataWithExpressions.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
 

--- a/Tableau-Supported/DotNet/InsertSpatialDataToAHyperFile.cs
+++ b/Tableau-Supported/DotNet/InsertSpatialDataToAHyperFile.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 using System.Collections.Generic;
 

--- a/Tableau-Supported/DotNet/Program.cs
+++ b/Tableau-Supported/DotNet/Program.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 using System.IO;
 

--- a/Tableau-Supported/DotNet/ReadDataFromExistingHyperFile.cs
+++ b/Tableau-Supported/DotNet/ReadDataFromExistingHyperFile.cs
@@ -1,13 +1,3 @@
-// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
 using System;
 using System.IO;
 

--- a/Tableau-Supported/DotNet/UpdateDataInExistingHyperFile.cs
+++ b/Tableau-Supported/DotNet/UpdateDataInExistingHyperFile.cs
@@ -1,14 +1,4 @@
-﻿// -----------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-// -----------------------------------------------------------------------------
-using System;
+﻿using System;
 using System.IO;
 
 using Tableau.HyperAPI;

--- a/Tableau-Supported/Java/create-hyper-file-from-csv/src/main/java/examples/CreateHyperFileFromCSV.java
+++ b/Tableau-Supported/Java/create-hyper-file-from-csv/src/main/java/examples/CreateHyperFileFromCSV.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.Connection;

--- a/Tableau-Supported/Java/delete-data-in-existing-hyper-file/src/main/java/examples/DeleteDataInExistingHyperFile.java
+++ b/Tableau-Supported/Java/delete-data-in-existing-hyper-file/src/main/java/examples/DeleteDataInExistingHyperFile.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// Unlicensed use of the contents of this file is prohibited. Please refer to
-// the NOTICES.txt file for further details.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.Connection;

--- a/Tableau-Supported/Java/insert-data-into-multiple-tables/src/main/java/examples/InsertDataIntoMultipleTables.java
+++ b/Tableau-Supported/Java/insert-data-into-multiple-tables/src/main/java/examples/InsertDataIntoMultipleTables.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.Catalog;

--- a/Tableau-Supported/Java/insert-data-into-single-table/src/main/java/examples/InsertDataIntoSingleTable.java
+++ b/Tableau-Supported/Java/insert-data-into-single-table/src/main/java/examples/InsertDataIntoSingleTable.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.*;

--- a/Tableau-Supported/Java/insert-data-with-expressions/src/main/java/examples/InsertDataWithExpressions.java
+++ b/Tableau-Supported/Java/insert-data-with-expressions/src/main/java/examples/InsertDataWithExpressions.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.*;

--- a/Tableau-Supported/Java/insert-spatial-data-to-a-hyper-file/src/main/java/examples/InsertSpatialDataToAHyperFile.java
+++ b/Tableau-Supported/Java/insert-spatial-data-to-a-hyper-file/src/main/java/examples/InsertSpatialDataToAHyperFile.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.*;

--- a/Tableau-Supported/Java/read-and-print-data-from-existing-hyper-file/src/main/java/examples/ReadAndPrintDataFromExistingHyperFile.java
+++ b/Tableau-Supported/Java/read-and-print-data-from-existing-hyper-file/src/main/java/examples/ReadAndPrintDataFromExistingHyperFile.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.Catalog;

--- a/Tableau-Supported/Java/update-data-in-existing-hyper-file/src/main/java/examples/UpdateDataInExistingHyperFile.java
+++ b/Tableau-Supported/Java/update-data-in-existing-hyper-file/src/main/java/examples/UpdateDataInExistingHyperFile.java
@@ -1,13 +1,3 @@
-//---------------------------------------------------------------------------
-//
-// This file is the copyrighted property of Tableau Software and is protected
-// by registered patents and other applicable U.S. and international laws and
-// regulations.
-//
-// You may adapt this file and modify it to fit into your context and use it
-// as a template to start your own projects.
-//
-//---------------------------------------------------------------------------
 package examples;
 
 import com.tableau.hyperapi.Connection;

--- a/Tableau-Supported/Python/create_hyper_file_from_csv.py
+++ b/Tableau-Supported/Python/create_hyper_file_from_csv.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 from pathlib import Path
 
 from tableauhyperapi import HyperProcess, Telemetry, \

--- a/Tableau-Supported/Python/delete_data_in_existing_hyper_file.py
+++ b/Tableau-Supported/Python/delete_data_in_existing_hyper_file.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 import shutil
 
 from pathlib import Path

--- a/Tableau-Supported/Python/insert_data_into_multiple_tables.py
+++ b/Tableau-Supported/Python/insert_data_into_multiple_tables.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 from datetime import datetime
 from pathlib import Path
 

--- a/Tableau-Supported/Python/insert_data_into_single_table.py
+++ b/Tableau-Supported/Python/insert_data_into_single_table.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 from pathlib import Path
 
 from tableauhyperapi import HyperProcess, Telemetry, \

--- a/Tableau-Supported/Python/insert_data_with_expressions.py
+++ b/Tableau-Supported/Python/insert_data_with_expressions.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 import shutil
 
 from pathlib import Path

--- a/Tableau-Supported/Python/insert_spatial_data_to_a_hyper_file.py
+++ b/Tableau-Supported/Python/insert_spatial_data_to_a_hyper_file.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 import shutil
 
 from pathlib import Path

--- a/Tableau-Supported/Python/read_and_print_data_from_existing_hyper_file.py
+++ b/Tableau-Supported/Python/read_and_print_data_from_existing_hyper_file.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 import shutil
 
 from pathlib import Path

--- a/Tableau-Supported/Python/update_data_in_existing_hyper_file.py
+++ b/Tableau-Supported/Python/update_data_in_existing_hyper_file.py
@@ -1,13 +1,3 @@
-# -----------------------------------------------------------------------------
-#
-# This file is the copyrighted property of Tableau Software and is protected
-# by registered patents and other applicable U.S. and international laws and
-# regulations.
-#
-# You may adapt this file and modify it to fit into your context and use it
-# as a template to start your own projects.
-#
-# -----------------------------------------------------------------------------
 import shutil
 
 from pathlib import Path


### PR DESCRIPTION
This commit brings the samples in sync with the HAPI July 2022 release.