### PR TITLE
Remove version pinning from git-to-hyper example

### DIFF
--- a/Community-Supported/git-to-hyper/requirements.txt
+++ b/Community-Supported/git-to-hyper/requirements.txt
@@ -1,2 +1,2 @@
-GitPython==3.1.30
-tableauhyperapi==0.0.15735
+GitPython
+tableauhyperapi


### PR DESCRIPTION
Pinned version might lead to the case that users are using outdated versions with known vulnerabilities, as we do not guarantee active maintenance of Community Supported examples. As Salesforce values Trust and Security above all other things we rather accept that our example might break with future releases of our dependencies than risking that our users are making themselves vulnerable because of us.